### PR TITLE
Fix getObject on missing '/Annots'

### DIFF
--- a/PyPDF3/pdf.py
+++ b/PyPDF3/pdf.py
@@ -1749,8 +1749,9 @@ class PdfFileReader(object):
         else:
             warnings.warn("Object %d %d not defined." % (indirectReference.idnum,
                                                          indirectReference.generation), utils.PdfReadWarning)
-            # if self.strict:
-            raise utils.PdfReadError("Could not find object.")
+            if self.strict:
+                raise utils.PdfReadError("Could not find object.")
+
         self.cacheIndirectObject(indirectReference.generation,
                                  indirectReference.idnum, retval)
         return retval
@@ -2392,7 +2393,7 @@ class PageObject(DictionaryObject):
 
         for page in (self, page2):
             if "/Annots" in page:
-                annots = page["/Annots"]
+                annots = page.get('/Annots')
                 if isinstance(annots, ArrayObject):
                     for ref in annots:
                         newAnnots.append(ref)


### PR DESCRIPTION
In some PDF 1.5 files we have a '/Annots' section but no object for it. With that patch we can put our watermark without raising errors.


```
Traceback (most recent call last):
  File "/home/e/Repositories/p.pdf/p/pdf/views.py", line 224, in generatePdf
    watermark(tmp_prince_output.name, tmp_specimen_output.name)
  File "/home/e/Repositories/p.pdf/p/pdf/watermark.py", line 15, in watermark
    page.mergePage(watermark.getPage(0))
  File "/home/e/Repositories/p.pdf/eggs/PyPDF3-1.0.1-py2.7.egg/PyPDF3/pdf.py", line 2380, in mergePage
    self._mergePage(page2)
  File "/home/e/Repositories/p.pdf/eggs/PyPDF3-1.0.1-py2.7.egg/PyPDF3/pdf.py", line 2395, in _mergePage
    annots = page["/Annots"]
  File "/home/e/Repositories/p.pdf/eggs/PyPDF3-1.0.1-py2.7.egg/PyPDF3/generic.py", line 518, in __getitem__
    return dict.__getitem__(self, key).getObject()
  File "/home/e/Repositories/p.pdf/eggs/PyPDF3-1.0.1-py2.7.egg/PyPDF3/generic.py", line 179, in getObject
    return self.pdf.getObject(self).getObject()
AttributeError: 'NoneType' object has no attribute 'getObject'
```