### PR TITLE
sweepIndirectReferences() - handle RecursionError exception

### DIFF
--- a/PyPDF3/pdf.py
+++ b/PyPDF3/pdf.py
@@ -638,7 +638,7 @@ class PdfFileWriter(object):
                         newobj = self._sweepIndirectReferences(externMap, newobj)
                         self._objects[idnum - 1] = newobj
                         return newobj_ido
-                    except ValueError:
+                    except (ValueError, RecursionError):
                         # Unable to resolve the Object, returning NullObject instead.
                         warnings.warn("Unable to resolve [{}: {}], returning NullObject instead".format(
                             data.__class__.__name__, data


### PR DESCRIPTION
When merging a certain set of PDFs, RecursionError exception was thrown. This was how I worked around it.

A quick search around the internet gave a few results of others facing this exception while using PyPDF3. So I figured this might be helpful.

[This issue raised in the repository of PyPDF3's predecessor](https://github.com/mstamy2/PyPDF2/issues/520)

The big assumption for this patch is: If `sweepIndirectReferences()` recurses past the default python recursion limit. Then it is fair to assume that we are unable to resolve the indirect object.

A user can set Python's recursion limit to work around this issue. For example:
```
import sys
sys.setrecursionlimit(30000)
```
However, in my case, it did not help, and the Python interpreter exited with an error code without throwing RecursionError. I assume it is hitting another stack-based memory limit outside the scope of Python.