### PR TITLE
if not self.strict, ignore a /Prev entry with the value 0 in the trailer

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1942,6 +1942,15 @@ class PdfFileReader(object):
                 else:
                     break
             else:
+                # some PDFs have /Prev=0 in the trailer, instead of no /Prev
+                if startxref == 0:
+                    if self.strict:
+                        raise utils.PdfReadError("/Prev=0 in the trailer (try"
+                                                 " opening with strict=False)")
+                    else:
+                        warnings.warn("/Prev=0 in the trailer - assuming there"
+                                      " is no previous xref table")
+                        break
                 # bad xref character at startxref.  Let's see if we can find
                 # the xref table nearby, as we've observed this error with an
                 # off-by-one before.


### PR DESCRIPTION
fixes https://github.com/mstamy2/PyPDF2/issues/530