### PR TITLE
The "data.pdf" can be of type PdfFileWriter, which does not have a "stream" attribute.

### DIFF
--- a/PyPDF3/pdf.py
+++ b/PyPDF3/pdf.py
@@ -621,7 +621,7 @@ class PdfFileWriter(object):
                     self._sweepIndirectReferences(externMap, realdata)
                     return data
             else:
-                if data.pdf.stream.closed:
+                if hasattr(data.pdf, 'stream') and data.pdf.stream.closed:
                     raise ValueError("I/O operation on closed file: {}".format(data.pdf.stream.name))
                 newobj = externMap.get(data.pdf, {}).get(data.generation, {}).get(data.idnum, None)
                 if newobj == None:


### PR DESCRIPTION
The following code fails to write the output for the second page of the attached PDF. With the fix in the pull request it does work as expected.
Although I'm not quite sure if this is just a symptom of another problem that manifests itself there.

```
from PyPDF3 import PdfFileWriter, PdfFileReader

if __name__ == '__main__':
    input_pdf = PdfFileReader('2022-02-03_regiogis.pdf', strict=True)
    for p in [0, 1]:
        page = input_pdf.getPage(p)
        output_pdf = PdfFileWriter()
        output_pdf.addPage(page)
        with open('Page{}.pdf'.format(p), 'wb') as of:
            output_pdf.write(of)
```

[2022-02-03_regiogis.pdf](https://github.com/sfneal/PyPDF3/files/7992921/2022-02-03_regiogis.pdf)
